### PR TITLE
fix ERR_FR_MAX_BODY_LENGTH_EXCEEDED

### DIFF
--- a/diawi.js
+++ b/diawi.js
@@ -52,7 +52,8 @@ Diawi.prototype.execute = async function () {
     
     const config = { 
       headers: data.getHeaders() /* { 'Content-Type': 'multipart/form-data' } */,
-      maxContentLength: 100000000
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity
     };
 
     const response = await axios.post(UPLOAD_URL, data, config);


### PR DESCRIPTION
fixes failed diawi upload with the following error

`Failed:  Error: Error [ERR_FR_MAX_BODY_LENGTH_EXCEEDED]: Request body larger than maxBodyLength limit`

More info:

https://github.com/axios/axios/issues/1362
https://stackoverflow.com/questions/58655532/increasing-maxcontentlength-and-maxbodylength-in-axios